### PR TITLE
Configure SCM-driven versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nirviz"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Visualisation tool for the Neuromorphic Intermediate Representation"
 license-files = ["LICENSE"]
 license = "BSD-3-Clause"
@@ -39,3 +39,6 @@ homepage = "https://github.com/open-neuromorphic/nirviz"
 
 [tool.setuptools]
 packages = ["nirviz"]
+
+[tool.setuptools_scm]
+version_scheme = "post-release"


### PR DESCRIPTION
## Summary
- remove the static version from `pyproject.toml`
- declare `dynamic = ["version"]` for the project
- configure setuptools_scm to use `post-release` scheme

## Testing
- `pip install -e .`
- `python3 - <<'EOF'
import importlib.metadata
print(importlib.metadata.version('nirviz'))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684aae00bf7c832cb15197d4e93dd6c0